### PR TITLE
fix: simplify password reset redirectTo to bare callback URL

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -115,7 +115,7 @@ export default function AccountPage() {
     e.preventDefault();
     setBusy(true); clearMessage();
     const { error } = await createClient().auth.resetPasswordForEmail(email, {
-      redirectTo: `${window.location.origin}/auth/callback?next=/account&type=recovery`,
+      redirectTo: `${window.location.origin}/auth/callback`,
     });
     if (error) { setMessage({ type: "error", text: error.message }); setBusy(false); return; }
     setMessage({ type: "success", text: "Password reset email sent — check your inbox." });

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -5,8 +5,6 @@ import { cookies } from "next/headers";
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const type = searchParams.get("type"); // "recovery" passed via redirectTo
-  const next = searchParams.get("next") ?? "/";
 
   if (code) {
     const cookieStore = await cookies();
@@ -27,10 +25,7 @@ export async function GET(request: NextRequest) {
 
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      const dest = type === "recovery"
-        ? `${origin}/account?reset=1`
-        : `${origin}${next}`;
-      return NextResponse.redirect(dest);
+      return NextResponse.redirect(`${origin}/account?reset=1`);
     }
   }
 


### PR DESCRIPTION
Supabase was silently dropping the redirectTo when it contained query parameters (?next=&type=recovery), falling back to the site root URL. Simplified to https://circagame.com/auth/callback (no query params) which matches the allowed redirect URLs unambiguously.

Callback route now always redirects to /account?reset=1 on success since password reset is its only current use case.