### PR TITLE
fix: reset busy state after successful password set in reset flow

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -134,6 +134,7 @@ export default function AccountPage() {
     const { error } = await createClient().auth.updateUser({ password: newPassword });
     if (error) { setMessage({ type: "error", text: error.message }); setBusy(false); return; }
     setNewPassword(""); setConfirmPassword("");
+    setBusy(false);
     window.history.replaceState({}, "", "/account");
     loadAccount();
   }


### PR DESCRIPTION
Missing setBusy(false) on the success path caused all buttons to show their loading labels (updating…, opening…) after transitioning to signed-in.