### PR TITLE
fix: admin page date nav + orange bars + percentage labels

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -34,14 +34,15 @@ function formatSlug(slug: string): string {
 export default async function AdminPage({
   searchParams,
 }: {
-  searchParams: { date?: string };
+  searchParams: Promise<{ date?: string }>;
 }) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
 
   if (!user || !isAdminUser(user.id)) redirect("/");
 
-  const date = typeof searchParams.date === "string" ? searchParams.date : todayDate();
+  const params = await searchParams;
+  const date = typeof params.date === "string" ? params.date : todayDate();
   const prevDate = offsetDate(date, -1);
   const nextDate = offsetDate(date, 1);
 
@@ -145,7 +146,13 @@ export default async function AdminPage({
         ) : (
           <>
             {/* Score distribution */}
-            <ScoreDistribution buckets={buckets} totalPlayers={totalPlayers} />
+            <ScoreDistribution
+              buckets={buckets}
+              totalPlayers={totalPlayers}
+              branded
+              showPercentage
+              showPlayerCount={false}
+            />
 
             {/* Key stats */}
             <div className="grid grid-cols-2 gap-3">

--- a/components/ScoreDistribution.tsx
+++ b/components/ScoreDistribution.tsx
@@ -6,12 +6,18 @@ interface ScoreDistributionProps {
   buckets: DistributionBucket[];
   totalPlayers: number;
   userScore?: number;
+  branded?: boolean;
+  showPercentage?: boolean;
+  showPlayerCount?: boolean;
 }
 
 export default function ScoreDistribution({
   buckets,
   totalPlayers,
   userScore,
+  branded,
+  showPercentage,
+  showPlayerCount,
 }: ScoreDistributionProps) {
   if (totalPlayers === 0) return null;
 
@@ -50,9 +56,11 @@ export default function ScoreDistribution({
         <p className="font-recoleta text-xs font-semibold uppercase tracking-widest text-ink-muted">
           today&apos;s scores
         </p>
-        <p className="font-recoleta text-xs text-ink-muted">
-          {totalPlayers} {totalPlayers === 1 ? "player" : "players"}
-        </p>
+        {showPlayerCount !== false && (
+          <p className="font-recoleta text-xs text-ink-muted">
+            {totalPlayers} {totalPlayers === 1 ? "player" : "players"}
+          </p>
+        )}
       </div>
 
       <div className="rounded-2xl border border-ink/10 bg-surface/60 px-5 pt-5 pb-4 backdrop-blur-sm space-y-2">
@@ -72,7 +80,7 @@ export default function ScoreDistribution({
               <div className="flex-1 h-6 rounded-md overflow-hidden bg-ink/5 relative">
                 <div
                   className={`h-full rounded-md transition-all duration-500 ${
-                    active ? "bg-gold" : "bg-ink/15"
+                    active ? "bg-gold" : branded ? "bg-dot-orange/70" : "bg-ink/15"
                   }`}
                   style={{ width: `${Math.max(pct, bucket.count > 0 ? 2 : 0)}%` }}
                 />
@@ -82,7 +90,9 @@ export default function ScoreDistribution({
                       active ? "text-teal font-semibold" : "text-ink-muted"
                     }`}
                   >
-                    {bucket.count}
+                    {showPercentage
+                      ? `${Math.round((bucket.count / totalPlayers) * 100)}%`
+                      : bucket.count}
                   </span>
                 )}
               </div>


### PR DESCRIPTION
- Await searchParams (Next.js 15+ requires Promise) to fix date nav arrows
- Add branded/showPercentage/showPlayerCount props to ScoreDistribution
- Admin page uses orange bars, percentage labels, no player count display