### PR TITLE
fix: dark mode real-time toggle, legibility, and year input race cond…

### DIFF
--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -193,7 +193,7 @@ export default function AccountPage() {
         <NavHeader backHref="/" />
 
         <div className="space-y-1">
-          <h1 className="font-recoleta text-2xl font-bold text-teal">account</h1>
+          <h1 className="font-recoleta text-2xl font-bold text-teal dark:text-ink">account</h1>
         </div>
 
         {/* ---------------------------------------------------------------- */}
@@ -234,7 +234,7 @@ export default function AccountPage() {
               <p className="font-recoleta text-sm font-semibold text-ink">new to circa+?</p>
               <p className="font-recoleta text-xs text-ink-muted">create a free account to save your progress, then subscribe to unlock plus features.</p>
               <button onClick={() => { setView("create"); clearMessage(); }}
-                className="w-full rounded-2xl border border-ink/15 bg-teal py-3 font-recoleta text-sm font-semibold text-parchment hover:bg-teal/80 transition-colors">
+                className="w-full rounded-2xl border border-ink/15 bg-teal py-3 font-recoleta text-sm font-semibold text-parchment hover:bg-teal/80 transition-colors dark:bg-gold dark:text-ink dark:hover:bg-gold/80">
                 create account
               </button>
               <Link href="/plus" className="block w-full text-center font-recoleta text-sm font-semibold text-gold hover:text-gold/80 transition-colors">

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -160,7 +160,7 @@ export default async function AdminPage({
                 <p className="font-recoleta text-[10px] font-semibold uppercase tracking-widest text-ink-muted mb-1">
                   top score
                 </p>
-                <p className="font-recoleta text-2xl font-bold text-teal">
+                <p className="font-recoleta text-2xl font-bold text-teal dark:text-ink">
                   {topScore}
                 </p>
               </div>
@@ -168,7 +168,7 @@ export default async function AdminPage({
                 <p className="font-recoleta text-[10px] font-semibold uppercase tracking-widest text-ink-muted mb-1">
                   best streak
                 </p>
-                <p className="font-recoleta text-2xl font-bold text-teal">
+                <p className="font-recoleta text-2xl font-bold text-teal dark:text-ink">
                   {longestActiveStreak}
                   <span className="font-recoleta text-xs font-normal text-ink-muted ml-1">days</span>
                 </p>
@@ -184,7 +184,7 @@ export default async function AdminPage({
                 {perfectsPerEvent.map(({ eventId, slug, perfectCount }) => (
                   <div key={eventId} className="flex items-center justify-between px-4 py-2.5">
                     <p className="font-recoleta text-sm text-ink">{formatSlug(slug)}</p>
-                    <p className="font-recoleta text-sm font-semibold text-teal tabular-nums">
+                    <p className="font-recoleta text-sm font-semibold text-teal dark:text-ink tabular-nums">
                       {perfectCount}
                     </p>
                   </div>

--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -66,7 +66,7 @@ export default function ArchivePage() {
         <NavHeader backHref="/" />
 
         <div className="space-y-1">
-          <h1 className="font-recoleta text-3xl font-bold text-teal">archive</h1>
+          <h1 className="font-recoleta text-3xl font-bold text-teal dark:text-ink">archive</h1>
           <p className="font-recoleta text-sm text-ink-muted">every puzzle, playable anytime</p>
         </div>
 

--- a/app/dmca/page.tsx
+++ b/app/dmca/page.tsx
@@ -9,7 +9,7 @@ export default function DmcaPage() {
         <NavHeader backHref="/" />
 
         <div className="space-y-2">
-          <h1 className="font-serif text-3xl font-bold text-teal">dmca / copyright</h1>
+          <h1 className="font-serif text-3xl font-bold text-teal dark:text-ink">dmca / copyright</h1>
           <p className="font-sans text-xs text-ink-muted">Last updated: May 2, 2026</p>
         </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -74,6 +74,12 @@
   /* Primary teal button — add w-full and py-* per usage site */
   .btn-primary {
     @apply rounded-2xl bg-teal font-recoleta font-semibold text-parchment
-           transition-colors hover:bg-teal/80 active:scale-95 disabled:opacity-60;
+           transition-colors hover:bg-teal/80 active:scale-95 disabled:opacity-60
+           dark:bg-gold dark:text-ink dark:hover:bg-gold/80;
   }
+}
+
+/* Logo inverts to white in dark mode so it's visible on the teal background */
+[data-theme="dark"] .circa-logo {
+  filter: brightness(0) invert(1);
 }

--- a/app/groups/[id]/page.tsx
+++ b/app/groups/[id]/page.tsx
@@ -112,15 +112,15 @@ export default function GroupPage() {
     <PageShell>
       {/* Group header */}
       <div className="space-y-1">
-        <h1 className="font-recoleta text-2xl font-bold text-teal">{group.name}</h1>
+        <h1 className="font-recoleta text-2xl font-bold text-teal dark:text-ink">{group.name}</h1>
         <p className="font-recoleta text-sm text-ink-muted">{dateLabel}</p>
       </div>
 
       {/* Scoreboard */}
       <section className="rounded-2xl border border-ink/10 bg-surface/60 overflow-hidden">
         {scores && !scores.viewerHasPlayed && (
-          <div className="px-5 py-3 bg-cyan/80 border-b border-teal/15">
-            <p className="font-recoleta text-xs text-teal font-semibold text-center">
+          <div className="px-5 py-3 bg-surface/80 border-b border-ink/15">
+            <p className="font-recoleta text-xs text-teal dark:text-ink font-semibold text-center">
               play today&apos;s puzzle to see your friends&apos; scores
             </p>
           </div>
@@ -130,7 +130,7 @@ export default function GroupPage() {
           <div
             key={m.userId}
             className={`flex items-center gap-3 px-5 py-3.5 border-b border-ink/5 last:border-0 ${
-              m.userId === viewerUserId ? "bg-cyan/40" : ""
+              m.userId === viewerUserId ? "bg-surface/40" : ""
             }`}
           >
             {/* Rank */}

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -81,7 +81,7 @@ export default function GroupsPage() {
         <NavHeader backHref="/" />
 
         <div className="space-y-1">
-          <h1 className="font-recoleta text-3xl font-bold text-teal">groups</h1>
+          <h1 className="font-recoleta text-3xl font-bold text-teal dark:text-ink">groups</h1>
           <p className="font-recoleta text-sm text-ink-muted">play with friends and compare scores</p>
         </div>
 

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -100,7 +100,7 @@ export default function HelpPage() {
         <NavHeader backHref="/" />
 
         <div className="space-y-1">
-          <h1 className="font-recoleta text-3xl font-bold text-teal">help & settings</h1>
+          <h1 className="font-recoleta text-3xl font-bold text-teal dark:text-ink">help & settings</h1>
           <p className="font-recoleta text-sm text-ink-muted">how to play, scoring, and preferences</p>
         </div>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className="bg-parchment font-recoleta text-ink antialiased">
-          <SettingsProvider />
+        <SettingsProvider>
           {children}
           <footer className="py-6 text-center">
             <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 font-recoleta text-xs text-ink-muted/50">
@@ -33,6 +33,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <Link href="/dmca" className="hover:text-ink-muted transition-colors">DMCA / Copyright</Link>
             </div>
           </footer>
+        </SettingsProvider>
         </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -36,7 +36,7 @@ function LoginForm() {
   return (
     <div className="space-y-6">
       <div className="space-y-1">
-        <h1 className="font-recoleta text-2xl font-bold text-teal">sign in</h1>
+        <h1 className="font-recoleta text-2xl font-bold text-teal dark:text-ink">sign in</h1>
         <p className="font-recoleta text-sm text-ink-muted">
           Access your Circa+ features and saved progress.
         </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,7 @@ export default function HomePage() {
         </div>
 
         {/* Description */}
-        <div className="rounded-2xl bg-cyan p-6 text-left space-y-3">
+        <div className="rounded-2xl bg-surface p-6 text-left space-y-3">
           <p className="font-recoleta text-lg text-ink leading-relaxed">
             five moments in history. when did they happen?
           </p>
@@ -39,7 +39,7 @@ export default function HomePage() {
         {/* CTA */}
         <Link
           href="/play"
-          className="inline-block w-full rounded-2xl bg-teal py-4 font-recoleta font-semibold text-parchment transition-colors hover:bg-teal/80 active:scale-95 text-center"
+          className="inline-block w-full rounded-2xl bg-teal py-4 font-recoleta font-semibold text-parchment transition-colors hover:bg-teal/80 active:scale-95 text-center dark:bg-gold dark:text-ink dark:hover:bg-gold/80"
         >
           play today&apos;s puzzle
         </Link>

--- a/app/plus/page.tsx
+++ b/app/plus/page.tsx
@@ -109,7 +109,7 @@ function PricingCard({ plan, price, period, badge, onSelect, loading, disabled }
     <div
       className={`relative rounded-2xl border p-6 space-y-4 ${
         isAnnual
-          ? "border-gold/50 bg-cyan/60 ring-2 ring-gold/20"
+          ? "border-gold/50 bg-surface/60 ring-2 ring-gold/20"
           : "border-ink/10 bg-surface/60"
       } backdrop-blur-sm`}
     >
@@ -255,7 +255,7 @@ export default function PlusPage() {
           <div className="flex justify-center">
             <PlusBadge size="md" />
           </div>
-          <h1 className="font-recoleta text-4xl font-bold text-teal">circa+</h1>
+          <h1 className="font-recoleta text-4xl font-bold text-teal dark:text-ink">circa+</h1>
           <p className="font-recoleta text-sm text-ink-muted leading-relaxed max-w-sm mx-auto">
             for history lovers who want to go deeper. unlock the archive, protect your streak, and track every guess.
           </p>
@@ -277,7 +277,7 @@ export default function PlusPage() {
         {plusStatus?.isPlus ? (
           /* ── Already subscribed ── */
           <div className="space-y-4">
-            <div className="rounded-2xl border border-gold/40 bg-cyan/60 p-6 space-y-3 backdrop-blur-sm">
+            <div className="rounded-2xl border border-gold/40 bg-surface/60 p-6 space-y-3 backdrop-blur-sm">
               <div className="flex items-center justify-between">
                 <p className="font-recoleta text-sm font-semibold text-ink">you&apos;re a plus member</p>
                 <PlusBadge size="sm" />

--- a/app/plus/success/page.tsx
+++ b/app/plus/success/page.tsx
@@ -115,7 +115,7 @@ function SuccessInner() {
           <div className="flex justify-center">
             <PlusBadge size="md" />
           </div>
-          <h1 className="font-recoleta text-3xl font-bold text-teal">payment successful!</h1>
+          <h1 className="font-recoleta text-3xl font-bold text-teal dark:text-ink">payment successful!</h1>
           <p className="font-recoleta text-sm text-ink-muted">
             Sign in to activate your Plus features.
           </p>
@@ -166,7 +166,7 @@ function SuccessInner() {
         <div className="flex justify-center">
           <PlusBadge size="md" />
         </div>
-        <h1 className="font-recoleta text-3xl font-bold text-teal">welcome to plus</h1>
+        <h1 className="font-recoleta text-3xl font-bold text-teal dark:text-ink">welcome to plus</h1>
         <p className="font-recoleta text-sm text-ink-muted leading-relaxed max-w-xs mx-auto">
           Your subscription is active. The full archive, stats, streak shields, and groups are now unlocked.
         </p>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -9,7 +9,7 @@ export default function PrivacyPage() {
         <NavHeader backHref="/" />
 
         <div className="space-y-2">
-          <h1 className="font-serif text-3xl font-bold text-teal">privacy policy</h1>
+          <h1 className="font-serif text-3xl font-bold text-teal dark:text-ink">privacy policy</h1>
           <p className="font-sans text-sm text-ink-muted">Circa Game · Operated by Charbella Games LLC</p>
           <p className="font-sans text-xs text-ink-muted">Effective Date: May 2, 2026</p>
         </div>

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -140,7 +140,7 @@ export default function StatsPage() {
         <NavHeader backHref="/" />
 
         <div className="space-y-1">
-          <h1 className="font-recoleta text-3xl font-bold text-teal">stats</h1>
+          <h1 className="font-recoleta text-3xl font-bold text-teal dark:text-ink">stats</h1>
           <p className="font-recoleta text-sm text-ink-muted">all-time performance</p>
         </div>
 

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -9,7 +9,7 @@ export default function TermsPage() {
         <NavHeader backHref="/" />
 
         <div className="space-y-2">
-          <h1 className="font-serif text-3xl font-bold text-teal">terms of service</h1>
+          <h1 className="font-serif text-3xl font-bold text-teal dark:text-ink">terms of service</h1>
           <p className="font-sans text-sm text-ink-muted">Circa Game · Operated by Charbella Games LLC</p>
           <p className="font-sans text-xs text-ink-muted">Effective Date: May 2, 2026</p>
         </div>

--- a/components/CircaLogo.tsx
+++ b/components/CircaLogo.tsx
@@ -11,7 +11,7 @@ export default function CircaLogo({ className = "" }: CircaLogoProps) {
       alt="Circa"
       width={320}
       height={320}
-      className={className}
+      className={`${className} circa-logo`}
       priority
     />
   );

--- a/components/LinkAccountPrompt.tsx
+++ b/components/LinkAccountPrompt.tsx
@@ -41,7 +41,7 @@ export default function LinkAccountPrompt() {
   }
 
   return (
-    <div className="rounded-2xl border border-teal/20 bg-cyan/60 p-6 space-y-4">
+    <div className="rounded-2xl border border-ink/20 bg-surface/60 p-6 space-y-4">
       <div className="space-y-1">
         <p className="font-recoleta text-lg font-bold text-ink">protect your streak</p>
         <p className="font-recoleta text-sm text-ink-muted leading-relaxed">

--- a/components/PlusGate.tsx
+++ b/components/PlusGate.tsx
@@ -16,7 +16,7 @@ export default function PlusGate({ children, locked, feature }: PlusGateProps) {
   if (!locked) return <>{children}</>;
 
   return (
-    <div className="rounded-2xl border border-teal/20 bg-cyan/60 p-8 text-center space-y-4">
+    <div className="rounded-2xl border border-ink/20 bg-surface/60 p-8 text-center space-y-4">
       <div className="flex justify-center">
         <PlusBadge size="md" />
       </div>

--- a/components/ResultsCard.tsx
+++ b/components/ResultsCard.tsx
@@ -69,7 +69,7 @@ export default function ResultsCard({ result, distribution, groups }: ResultsCar
         <p className="text-xs font-recoleta font-semibold uppercase tracking-widest text-ink-muted">
           {dateLabel}
         </p>
-        <h2 className="font-recoleta text-3xl font-bold text-teal">today&apos;s results</h2>
+        <h2 className="font-recoleta text-3xl font-bold text-teal dark:text-ink">today&apos;s results</h2>
         <div className="flex justify-center pt-1">
           <StreakBadge streak={result.streak} />
         </div>

--- a/components/ScoreDistribution.tsx
+++ b/components/ScoreDistribution.tsx
@@ -87,7 +87,7 @@ export default function ScoreDistribution({
                 {bucket.count > 0 && (
                   <span
                     className={`absolute inset-y-0 left-2 flex items-center font-recoleta text-xs ${
-                      active ? "text-teal font-semibold" : "text-ink-muted"
+                      active ? "text-teal dark:text-gold font-semibold" : "text-ink-muted"
                     }`}
                   >
                     {showPercentage

--- a/components/SettingsProvider.tsx
+++ b/components/SettingsProvider.tsx
@@ -1,14 +1,52 @@
 "use client";
 
-import { useEffect } from "react";
-import { useSettings } from "@/lib/settings";
+import { useCallback, useEffect, useState } from "react";
+import {
+  SettingsContext,
+  SETTINGS_DEFAULTS,
+  SETTINGS_STORAGE_KEY,
+  type Settings,
+} from "@/lib/settings";
 
-export default function SettingsProvider() {
-  const { settings } = useSettings();
+function load(): Settings {
+  if (typeof window === "undefined") return SETTINGS_DEFAULTS;
+  try {
+    const raw = localStorage.getItem(SETTINGS_STORAGE_KEY);
+    return raw ? { ...SETTINGS_DEFAULTS, ...JSON.parse(raw) } : SETTINGS_DEFAULTS;
+  } catch {
+    return SETTINGS_DEFAULTS;
+  }
+}
+
+function save(settings: Settings) {
+  try {
+    localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  } catch { /* ignore quota errors */ }
+}
+
+export default function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [settings, setSettings] = useState<Settings>(SETTINGS_DEFAULTS);
+
+  useEffect(() => {
+    setSettings(load());
+  }, []);
 
   useEffect(() => {
     document.documentElement.dataset.theme = settings.darkMode ? "dark" : "light";
+    document.documentElement.classList.toggle("dark", settings.darkMode);
   }, [settings.darkMode]);
 
-  return null;
+  const update = useCallback(<K extends keyof Settings>(key: K, value: Settings[K]) => {
+    setSettings((prev) => {
+      const next = { ...prev, [key]: value };
+      save(next);
+      return next;
+    });
+  }, []);
+
+  return (
+    <SettingsContext.Provider value={{ settings, update }}>
+      {children}
+    </SettingsContext.Provider>
+  );
 }

--- a/components/YearSlider.tsx
+++ b/components/YearSlider.tsx
@@ -102,7 +102,12 @@ export default function YearSlider({ value, onChange, disabled = false }: YearSl
   }
 
   function handleYearInputChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setInputText(e.target.value);
+    const text = e.target.value;
+    setInputText(text);
+    const parsed = parseInt(text, 10);
+    if (!isNaN(parsed)) {
+      onChange(clamp(parsed));
+    }
   }
 
   function commitYearInput() {

--- a/lib/settings.ts
+++ b/lib/settings.ts
@@ -1,49 +1,29 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { createContext, useContext } from "react";
 
 export interface Settings {
   soundEnabled: boolean;
   darkMode: boolean;
 }
 
-const DEFAULTS: Settings = {
+export const SETTINGS_DEFAULTS: Settings = {
   soundEnabled: true,
   darkMode: false,
 };
 
-const STORAGE_KEY = "circa_settings";
+export const SETTINGS_STORAGE_KEY = "circa_settings";
 
-function load(): Settings {
-  if (typeof window === "undefined") return DEFAULTS;
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    return raw ? { ...DEFAULTS, ...JSON.parse(raw) } : DEFAULTS;
-  } catch {
-    return DEFAULTS;
-  }
+interface SettingsContextValue {
+  settings: Settings;
+  update: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
 }
 
-function save(settings: Settings) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
-  } catch { /* ignore quota errors */ }
-}
+export const SettingsContext = createContext<SettingsContextValue>({
+  settings: SETTINGS_DEFAULTS,
+  update: () => {},
+});
 
 export function useSettings() {
-  const [settings, setSettings] = useState<Settings>(DEFAULTS);
-
-  useEffect(() => {
-    setSettings(load());
-  }, []);
-
-  const update = useCallback(<K extends keyof Settings>(key: K, value: Settings[K]) => {
-    setSettings((prev) => {
-      const next = { ...prev, [key]: value };
-      save(next);
-      return next;
-    });
-  }, []);
-
-  return { settings, update };
+  return useContext(SettingsContext);
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "class",
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
…ition

- Refactor settings into a shared React context so toggling dark mode on the help page takes effect immediately without a page refresh
- Add Tailwind darkMode: 'class' and toggle the dark class on <html>
  alongside the existing data-theme attribute
- Fix logo visibility in dark mode with CSS brightness/invert filter
- Replace static bg-cyan with themeable bg-surface on all cards/panels
- Add dark:bg-gold dark:text-ink to teal CTA buttons (teal = page bg in dark mode)
- Add dark:text-ink to all text-teal headings across every page
- Fix btn-primary utility class for dark mode in globals.css
- Fix YearSlider to call onChange on every keypress so lock-in always uses the typed year without requiring Enter or blur first